### PR TITLE
Fix dependabot reviewer username capitalization to Adacchi3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       default-days: 7
     open-pull-requests-limit: 10
     reviewers:
-      - adacchi3
+      - Adacchi3
     groups:
       react:
         patterns:
@@ -28,7 +28,7 @@ updates:
       default-days: 7
     open-pull-requests-limit: 3
     reviewers:
-      - adacchi3
+      - Adacchi3
     groups:
       actions-minor-and-patch:
         update-types:


### PR DESCRIPTION
## What
dependabot.yml の reviewers を `adacchi3` から `Adacchi3` に修正。

## How
`.github/dependabot.yml` の npm および github-actions 両エコシステムの reviewers エントリを大文字化。

## Why
GitHub のユーザー名は大文字・小文字を区別しないが、正式なユーザー名 `Adacchi3` に統一するため。