### PR TITLE
Add JSON-LD structured data for SEO

### DIFF
--- a/app/(en)/en/page.tsx
+++ b/app/(en)/en/page.tsx
@@ -1,6 +1,7 @@
 import { prefetchTopData } from '@client'
 import ApolloHydrator from '@components/atoms/ApolloHydrator'
 import TopTemplate from '@components/templates/TopTemplate'
+import { buildPersonJsonLd } from '@lib/jsonLd'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
@@ -8,10 +9,17 @@ export const metadata: Metadata = {
 }
 
 export default async function Page() {
-  const apolloState = await prefetchTopData('en-US')
+  const { apolloState, data } = await prefetchTopData('en-US')
+  const personJsonLd = buildPersonJsonLd(data, 'en-US')
   return (
-    <ApolloHydrator apolloState={apolloState} locale="en-US">
-      <TopTemplate />
-    </ApolloHydrator>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+      />
+      <ApolloHydrator apolloState={apolloState} locale="en-US">
+        <TopTemplate />
+      </ApolloHydrator>
+    </>
   )
 }

--- a/app/(en)/en/page.tsx
+++ b/app/(en)/en/page.tsx
@@ -1,7 +1,7 @@
 import { prefetchTopData } from '@client'
 import ApolloHydrator from '@components/atoms/ApolloHydrator'
 import TopTemplate from '@components/templates/TopTemplate'
-import { buildPersonJsonLd } from '@lib/jsonLd'
+import { buildPersonJsonLd, serializeJsonLd } from '@lib/jsonLd'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
@@ -15,7 +15,7 @@ export default async function Page() {
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(personJsonLd) }}
       />
       <ApolloHydrator apolloState={apolloState} locale="en-US">
         <TopTemplate />

--- a/app/(en)/layout.tsx
+++ b/app/(en)/layout.tsx
@@ -1,4 +1,4 @@
-import { buildWebSiteJsonLd } from '@lib/jsonLd'
+import { buildWebSiteJsonLd, serializeJsonLd } from '@lib/jsonLd'
 import { ANTI_FLASH_SCRIPT } from '@utils/theme'
 import type { Metadata } from 'next'
 import { Providers } from '../providers'
@@ -31,7 +31,7 @@ export default function RootLayout({
         <script dangerouslySetInnerHTML={{ __html: ANTI_FLASH_SCRIPT }} />
         <script
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(webSiteJsonLd) }}
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(webSiteJsonLd) }}
         />
         <link
           rel="preconnect"

--- a/app/(en)/layout.tsx
+++ b/app/(en)/layout.tsx
@@ -1,7 +1,10 @@
+import { buildWebSiteJsonLd } from '@lib/jsonLd'
 import { ANTI_FLASH_SCRIPT } from '@utils/theme'
 import type { Metadata } from 'next'
 import { Providers } from '../providers'
 import '@styles/globals.css'
+
+const webSiteJsonLd = buildWebSiteJsonLd('en')
 
 export const metadata: Metadata = {
   title: 'Adacchi3 Portfolio',
@@ -26,6 +29,10 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <head>
         <script dangerouslySetInnerHTML={{ __html: ANTI_FLASH_SCRIPT }} />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(webSiteJsonLd) }}
+        />
         <link
           rel="preconnect"
           href="https://images.ctfassets.net"

--- a/app/(ja)/layout.tsx
+++ b/app/(ja)/layout.tsx
@@ -1,4 +1,4 @@
-import { buildWebSiteJsonLd } from '@lib/jsonLd'
+import { buildWebSiteJsonLd, serializeJsonLd } from '@lib/jsonLd'
 import { ANTI_FLASH_SCRIPT } from '@utils/theme'
 import type { Metadata } from 'next'
 import { Providers } from '../providers'
@@ -31,7 +31,7 @@ export default function RootLayout({
         <script dangerouslySetInnerHTML={{ __html: ANTI_FLASH_SCRIPT }} />
         <script
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(webSiteJsonLd) }}
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(webSiteJsonLd) }}
         />
         <link
           rel="preconnect"

--- a/app/(ja)/layout.tsx
+++ b/app/(ja)/layout.tsx
@@ -1,7 +1,10 @@
+import { buildWebSiteJsonLd } from '@lib/jsonLd'
 import { ANTI_FLASH_SCRIPT } from '@utils/theme'
 import type { Metadata } from 'next'
 import { Providers } from '../providers'
 import '@styles/globals.css'
+
+const webSiteJsonLd = buildWebSiteJsonLd('ja')
 
 export const metadata: Metadata = {
   title: 'Adacchi3 Portfolio',
@@ -26,6 +29,10 @@ export default function RootLayout({
     <html lang="ja" suppressHydrationWarning>
       <head>
         <script dangerouslySetInnerHTML={{ __html: ANTI_FLASH_SCRIPT }} />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(webSiteJsonLd) }}
+        />
         <link
           rel="preconnect"
           href="https://images.ctfassets.net"

--- a/app/(ja)/page.tsx
+++ b/app/(ja)/page.tsx
@@ -1,7 +1,7 @@
 import { prefetchTopData } from '@client'
 import ApolloHydrator from '@components/atoms/ApolloHydrator'
 import TopTemplate from '@components/templates/TopTemplate'
-import { buildPersonJsonLd } from '@lib/jsonLd'
+import { buildPersonJsonLd, serializeJsonLd } from '@lib/jsonLd'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
@@ -15,7 +15,7 @@ export default async function Page() {
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(personJsonLd) }}
       />
       <ApolloHydrator apolloState={apolloState} locale="ja-JP">
         <TopTemplate />

--- a/app/(ja)/page.tsx
+++ b/app/(ja)/page.tsx
@@ -1,6 +1,7 @@
 import { prefetchTopData } from '@client'
 import ApolloHydrator from '@components/atoms/ApolloHydrator'
 import TopTemplate from '@components/templates/TopTemplate'
+import { buildPersonJsonLd } from '@lib/jsonLd'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
@@ -8,10 +9,17 @@ export const metadata: Metadata = {
 }
 
 export default async function Page() {
-  const apolloState = await prefetchTopData('ja-JP')
+  const { apolloState, data } = await prefetchTopData('ja-JP')
+  const personJsonLd = buildPersonJsonLd(data, 'ja-JP')
   return (
-    <ApolloHydrator apolloState={apolloState} locale="ja-JP">
-      <TopTemplate />
-    </ApolloHydrator>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+      />
+      <ApolloHydrator apolloState={apolloState} locale="ja-JP">
+        <TopTemplate />
+      </ApolloHydrator>
+    </>
   )
 }

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -68,7 +68,6 @@ export function initializeApollo(initialState: object | null = null) {
 
   // For SSG and SSR always create a new Apollo Client
   if (typeof window === 'undefined') return _apolloClient
-  // Create the Apollo Client once in the client
   if (!apolloClient) apolloClient = _apolloClient
   return _apolloClient
 }

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -1,5 +1,6 @@
 import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client'
 import { TopDocument } from '@graphql/documents'
+import type { TopQuery } from '@graphql/generated/graphql'
 import merge from 'deepmerge'
 import isEqual from 'lodash/isEqual'
 
@@ -29,7 +30,7 @@ export function makeClient() {
 
 export async function prefetchTopData(locale: string) {
   const client = makeClient()
-  await client.query({
+  const { data } = await client.query<TopQuery>({
     query: TopDocument,
     variables: {
       preview: process.env.PREVIEW === 'true',
@@ -37,7 +38,10 @@ export async function prefetchTopData(locale: string) {
       authorId: String(process.env.AUTHOR_ID),
     },
   })
-  return JSON.parse(JSON.stringify(client.cache.extract()))
+  return {
+    apolloState: JSON.parse(JSON.stringify(client.cache.extract())) as object,
+    data,
+  }
 }
 
 export function initializeApollo(initialState: object | null = null) {

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -30,7 +30,7 @@ export function makeClient() {
 
 export async function prefetchTopData(locale: string) {
   const client = makeClient()
-  const { data } = await client.query<TopQuery>({
+  const result = await client.query<TopQuery>({
     query: TopDocument,
     variables: {
       preview: process.env.PREVIEW === 'true',
@@ -40,7 +40,8 @@ export async function prefetchTopData(locale: string) {
   })
   return {
     apolloState: JSON.parse(JSON.stringify(client.cache.extract())) as object,
-    data,
+    // Apollo Client 4 types data as TData | undefined even on success
+    data: result.data as unknown as TopQuery,
   }
 }
 

--- a/src/lib/jsonLd.ts
+++ b/src/lib/jsonLd.ts
@@ -1,0 +1,43 @@
+import type { TopQuery } from '@graphql/generated/graphql'
+
+const SITE_URL = 'https://adacchi3.github.io'
+
+export function buildWebSiteJsonLd(locale: 'ja' | 'en') {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: 'Adacchi3 Portfolio',
+    url: locale === 'en' ? `${SITE_URL}/en` : SITE_URL,
+  }
+}
+
+export function buildPersonJsonLd(data: TopQuery, locale: 'ja-JP' | 'en-US') {
+  const pageUrl = locale === 'en-US' ? `${SITE_URL}/en` : SITE_URL
+
+  const sameAs = (data.contacts?.items ?? [])
+    .filter((c): c is NonNullable<typeof c> => c?.link != null)
+    .map((c) => c.link as string)
+
+  const alumniOf = (data.academicBackgroundCollection?.items ?? [])
+    .filter((a): a is NonNullable<typeof a> => a?.organization != null)
+    .map((a) => ({ '@type': 'Organization', name: a.organization }))
+
+  const worksFor = (data.workExperiences?.items ?? [])
+    .filter(
+      (w): w is NonNullable<typeof w> =>
+        w?.organization != null && w?.endDate == null,
+    )
+    .map((w) => ({ '@type': 'Organization', name: w.organization }))
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: data.me?.name ?? '',
+    description: data.me?.description ?? '',
+    image: data.me?.image?.url ?? '',
+    url: pageUrl,
+    ...(sameAs.length > 0 ? { sameAs } : {}),
+    ...(alumniOf.length > 0 ? { alumniOf } : {}),
+    ...(worksFor.length > 0 ? { worksFor } : {}),
+  }
+}

--- a/src/lib/jsonLd.ts
+++ b/src/lib/jsonLd.ts
@@ -2,6 +2,10 @@ import type { TopQuery } from '@graphql/generated/graphql'
 
 const SITE_URL = 'https://adacchi3.github.io'
 
+export function serializeJsonLd(data: object): string {
+  return JSON.stringify(data).replace(/</g, '\\u003c')
+}
+
 export function buildWebSiteJsonLd(locale: 'ja' | 'en') {
   return {
     '@context': 'https://schema.org',
@@ -29,13 +33,18 @@ export function buildPersonJsonLd(data: TopQuery, locale: 'ja-JP' | 'en-US') {
     )
     .map((w) => ({ '@type': 'Organization', name: w.organization }))
 
+  const rawImageUrl = data.me?.image?.url
+  const imageUrl = rawImageUrl?.startsWith('//')
+    ? `https:${rawImageUrl}`
+    : rawImageUrl
+
   return {
     '@context': 'https://schema.org',
     '@type': 'Person',
-    name: data.me?.name ?? '',
-    description: data.me?.description ?? '',
-    image: data.me?.image?.url ?? '',
     url: pageUrl,
+    ...(data.me?.name ? { name: data.me.name } : {}),
+    ...(data.me?.description ? { description: data.me.description } : {}),
+    ...(imageUrl ? { image: imageUrl } : {}),
     ...(sameAs.length > 0 ? { sameAs } : {}),
     ...(alumniOf.length > 0 ? { alumniOf } : {}),
     ...(worksFor.length > 0 ? { worksFor } : {}),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
       "@client": ["./src/client"],
       "@graphql/*": ["./src/graphql/*"],
       "@hooks/*": ["./src/hooks/*"],
-      "@utils/*": ["./src/utils/*"]
+      "@utils/*": ["./src/utils/*"],
+      "@lib/*": ["./src/lib/*"]
     },
 
     // JavaScript Support


### PR DESCRIPTION
## Summary
This PR adds JSON-LD structured data markup to improve SEO and search engine understanding of the portfolio site. It implements both WebSite and Person schema types with dynamic data from the GraphQL API.

## Key Changes
- **New `src/lib/jsonLd.ts` module**: Created utility functions to generate JSON-LD structured data
  - `buildWebSiteJsonLd()`: Generates WebSite schema with locale-specific URLs
  - `buildPersonJsonLd()`: Generates Person schema with dynamic data including name, description, image, social links (sameAs), education (alumniOf), and current employment (worksFor)

- **Updated page layouts**: Added WebSite JSON-LD to both English and Japanese root layouts for global site-level metadata

- **Updated page components**: Added Person JSON-LD to both English and Japanese top pages with data fetched from GraphQL

- **Modified `prefetchTopData()` function**: Now returns both Apollo cache state and the raw GraphQL data, enabling use of query results in page components

- **Updated `tsconfig.json`**: Added `@lib/*` path alias for cleaner imports

## Implementation Details
- JSON-LD scripts are injected using Next.js `dangerouslySetInnerHTML` with proper `application/ld+json` type
- Person schema dynamically includes optional fields (sameAs, alumniOf, worksFor) only when data is available
- Locale-specific URLs are handled for both English (`/en`) and Japanese (root) versions
- Type-safe implementation using GraphQL generated types

https://claude.ai/code/session_01FKcCex8KrXnJrcSE6jqm2z