### PR TITLE
Normalize whitespace in Person JSON-LD description

### DIFF
--- a/src/lib/jsonLd.ts
+++ b/src/lib/jsonLd.ts
@@ -38,12 +38,14 @@ export function buildPersonJsonLd(data: TopQuery, locale: 'ja-JP' | 'en-US') {
     ? `https:${rawImageUrl}`
     : rawImageUrl
 
+  const description = data.me?.description?.replace(/\s+/g, ' ').trim()
+
   return {
     '@context': 'https://schema.org',
     '@type': 'Person',
     url: pageUrl,
     ...(data.me?.name ? { name: data.me.name } : {}),
-    ...(data.me?.description ? { description: data.me.description } : {}),
+    ...(description ? { description } : {}),
     ...(imageUrl ? { image: imageUrl } : {}),
     ...(sameAs.length > 0 ? { sameAs } : {}),
     ...(alumniOf.length > 0 ? { alumniOf } : {}),


### PR DESCRIPTION
## Summary
Normalize whitespace in the Person schema description by collapsing multiple consecutive whitespace characters into single spaces and trimming leading/trailing whitespace.

## Changes
- Extract description normalization logic into a separate variable before building the JSON-LD object
- Apply `.replace(/\s+/g, ' ')` to collapse multiple whitespace characters into single spaces
- Apply `.trim()` to remove leading and trailing whitespace
- Use the normalized description in the JSON-LD output

## Details
This ensures that descriptions with irregular whitespace formatting (multiple spaces, tabs, newlines, etc.) are normalized to a consistent format in the generated JSON-LD schema, improving data quality and consistency.

https://claude.ai/code/session_01FKcCex8KrXnJrcSE6jqm2z