### PR TITLE
Group graphql and graphql-codegen in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
           - "react"
           - "react-dom"
           - "@types/react"
+      graphql:
+        patterns:
+          - "graphql"
+          - "@graphql-codegen/*"
       npm-minor-and-patch:
         update-types:
           - minor


### PR DESCRIPTION
## What
Dependabot で `graphql` と `@graphql-codegen/*` をグループ化。

## How
`.github/dependabot.yml` に `graphql` グループを追加し、`graphql` と `@graphql-codegen/*` パターンを指定。

## Why
`graphql` と `@graphql-codegen/*` は peer dependency の関係にあり、片方だけ更新すると互換性が壊れる（#133 で発生）。グループ化することで、両方同時に更新可能なバージョンが出た際に1つの PR にまとまる。

## Ref
- #133

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUFgUwKLHyC1xYsDgXDaUB)_